### PR TITLE
Lock `cc` dev-dependency to 1.0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ libc="0.2"
 secp256k1="0.9"
 
 [build-dependencies]
-cc = { version = "1.0" }
+cc = { version = "=1.0.18" }
 
 [dev-dependencies]
 rustc-serialize = "0.3"


### PR DESCRIPTION
A workaround until alexcrichton/cc-rs#336 gets solved (or until Debian upgrades rustc).