### PR TITLE
Bump deps and pin cc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ libc="0.2"
 secp256k1="0.9"
 
 [build-dependencies]
-cc = { version = "1.0" }
+cc = "=1.0.26"
 
 [dev-dependencies]
 rustc-serialize = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ path = "src/lib.rs"
 
 [dependencies]
 libc="0.2"
-secp256k1="0.9"
 
 [build-dependencies]
 cc = "=1.0.26"
 
 [dev-dependencies]
 rustc-serialize = "0.3"
+secp256k1 = "0.12"


### PR DESCRIPTION
The cc crate keeps needlessly breaking build for no reason, and I'm getting kinda tired with dealing with the rust ecosystem's immaturity, so pin that, also bump the subtree and move secp to a dev-dep.