### PR TITLE
Relax cc dependency requirements, bump secp256k1 to 0.15 and bump version to 0.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.14.0
+  - 1.22.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoinconsensus"
-version = "0.16.5"
+version = "0.17.0"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoinconsensus/"
@@ -19,8 +19,8 @@ path = "src/lib.rs"
 libc="0.2"
 
 [build-dependencies]
-cc = ">= 1.0.28, <= 1.0.35"
+cc = ">= 1.0.36"
 
 [dev-dependencies]
 rustc-serialize = "0.3"
-secp256k1 = "0.13"
+secp256k1 = { version = "0.15", features = ["recovery"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoinconsensus"
-version = "0.16.4"
+version = "0.16.5"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoinconsensus/"
@@ -19,8 +19,8 @@ path = "src/lib.rs"
 libc="0.2"
 
 [build-dependencies]
-cc = "=1.0.26"
+cc = ">= 1.0.28, <= 1.0.35"
 
 [dev-dependencies]
 rustc-serialize = "0.3"
-secp256k1 = "0.12"
+secp256k1 = "0.13"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,9 @@ os: Visual Studio 2015
 
 environment:
   matrix:
-    - channel: 1.14.0
+    - channel: 1.22.0
       target: x86_64-pc-windows-msvc
-    - channel: 1.14.0
+    - channel: 1.22.0
       target: i686-pc-windows-msvc
       
     - channel: stable

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,6 @@ extern crate cc;
 use std::env;
 
 fn main() {
-    let target = env::var("TARGET").unwrap();
     let mut base_config = cc::Build::new();
     base_config
         .cpp(true)
@@ -19,22 +18,10 @@ fn main() {
     } else if tool.is_like_clang() || tool.is_like_gnu() {
         base_config.flag("-std=c++11").flag("-Wno-unused-parameter");
     }
-
-    if target == "x86_64-unknown-linux-gnu" {
+    #[cfg(target_os = "windows")]
+    {
         base_config
-            .define("HAVE_ENDIAN_H", Some("1"))
-            .define("HAVE_DECL_HTOBE16", Some("1"))
-            .define("HAVE_DECL_HTOLE16", Some("1"))
-            .define("HAVE_DECL_BE16TOH", Some("1"))
-            .define("HAVE_DECL_LE16TOH", Some("1"))
-            .define("HAVE_DECL_HTOBE32", Some("1"))
-            .define("HAVE_DECL_HTOLE32", Some("1"))
-            .define("HAVE_DECL_BE32TOH", Some("1"))
-            .define("HAVE_DECL_LE32TOH", Some("1"))
-            .define("HAVE_DECL_HTOBE64", Some("1"))
-            .define("HAVE_DECL_HTOLE64", Some("1"))
-            .define("HAVE_DECL_BE64TOH", Some("1"))
-            .define("HAVE_DECL_LE64TOH", Some("1"));
+            .define("WIN32", Some("1"));
     }
     base_config
         .file("bitcoin/src/utilstrencodings.cpp")


### PR DESCRIPTION
The current latest version of rust-bitcoinconsensus (0.16.4) is not compatible with secp256k1 0.13 since the cc requirements were relaxed (https://github.com/rust-bitcoin/rust-secp256k1/pull/103). The result is that when we update to secp256k1 in rust-bitcoin rust will pick bitcoinconsensus 0.16.3. The problem is that rust 1.22 has a bug where the attempt to resolve dependencies in such a way leads to an infinite loop. My hypothesis is that this PR will fix the problem and allow rust-bitcoin to update its secp256k1 version (see PR https://github.com/rust-bitcoin/rust-bitcoin/pull/278).