### PR TITLE
Updated the code style

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,5 @@
 extern crate cc;
 
-use std::env;
-
 fn main() {
     let mut base_config = cc::Build::new();
     base_config
@@ -20,8 +18,7 @@ fn main() {
     }
     #[cfg(target_os = "windows")]
     {
-        base_config
-            .define("WIN32", Some("1"));
+        base_config.define("WIN32", Some("1"));
     }
     base_config
         .file("bitcoin/src/utilstrencodings.cpp")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,9 @@ pub fn verify(spent_output: &[u8], amount: u64, spending_transaction: &[u8], inp
 /// Same as verify but with flags that turn past soft fork features on or off
 pub fn verify_with_flags(spent_output_script: &[u8], amount: u64, spending_transaction: &[u8], input_index: usize, flags: u32,) -> Result<(), Error> {
     let mut error = Error::ERR_SCRIPT;
+    if spent_output_script.is_empty() || spending_transaction.is_empty() {
+        return Err(error);
+    }
     let ret = unsafe {
         bitcoinconsensus_verify_script_with_amount(
             spent_output_script.as_ptr(),


### PR DESCRIPTION
1. Removed `uint64_t` which is deprecated (https://github.com/rust-lang/libc/issues/1304)
2. Added ZST checks for empty slices (https://github.com/rust-bitcoin/rust-secp256k1/issues/142)
3. General formatting to remove unused stuff and fix nits.