### PR TITLE
Compile libsecp256k1 ourselves

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "bitcoin"]
-	path = bitcoin
+[submodule "depend/bitcoin"]
+	path = depend/bitcoin
 	url = https://github.com/bitcoin/bitcoin.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ external-secp = []
 libc="0.2"
 
 [build-dependencies]
-cc = ">= 1.0.36"
+cc = ">= 1.0.36, <= 1.0.41"
 
 [dev-dependencies]
 rustc-serialize = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/lib.rs"
 
 [dependencies]
 libc="0.2"
-secp256k1 = { version = "0.15", features = ["recovery"] }
 
 [build-dependencies]
 cc = ">= 1.0.36"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ build = "build.rs"
 name = "bitcoinconsensus"
 path = "src/lib.rs"
 
+[features]
+external-secp = []
+
 [dependencies]
 libc="0.2"
 

--- a/build.rs
+++ b/build.rs
@@ -3,12 +3,47 @@ extern crate cc;
 use std::env;
 
 fn main() {
+    // Check whether we can use 64-bit compilation
+    let use_64bit_compilation = if env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap() == "64" {
+        let check = cc::Build::new()
+            .file("depend/check_uint128_t.c")
+            .cargo_metadata(false)
+            .try_compile("check_uint128_t")
+            .is_ok();
+        if !check {
+            println!("cargo:warning=Compiling in 32-bit mode on a 64-bit architecture due to lack of uint128_t support.");
+        }
+        check
+    } else {
+        false
+    };
     let mut base_config = cc::Build::new();
     base_config
         .cpp(true)
         .include("depend/bitcoin/src")
         .include("depend/bitcoin/src/secp256k1/include")
-        .define("__STDC_FORMAT_MACROS", None);
+        .define("__STDC_FORMAT_MACROS", None)
+        // **Secp256k1**
+        .include("depend/bitcoin/src/secp256k1")
+        .flag_if_supported("-Wno-unused-function") // some ecmult stuff is defined but not used upstream
+        .define("SECP256K1_BUILD", "1")
+        // Bitcoin core defines libsecp to *not* use libgmp.
+        .define("USE_NUM_NONE", "1")
+        .define("USE_FIELD_INV_BUILTIN", "1")
+        .define("USE_SCALAR_INV_BUILTIN", "1")
+        // Technically libconsensus doesn't require the recovery feautre, but `pubkey.cpp` does.
+        .define("ENABLE_MODULE_RECOVERY", "1");
+
+    if use_64bit_compilation {
+        base_config
+            .define("USE_FIELD_5X52", "1")
+            .define("USE_SCALAR_4X64", "1")
+            .define("HAVE___INT128", "1");
+    } else {
+        base_config
+            .define("USE_FIELD_10X26", "1")
+            .define("USE_SCALAR_8X32", "1");
+    }
 
     let tool = base_config.get_compiler();
     if tool.is_like_msvc() {
@@ -18,8 +53,7 @@ fn main() {
     }
     #[cfg(target_os = "windows")]
     {
-        base_config
-            .define("WIN32", Some("1"));
+        base_config.define("WIN32", Some("1"));
     }
     base_config
         .file("depend/bitcoin/src/utilstrencodings.cpp")
@@ -36,5 +70,6 @@ fn main() {
         .file("depend/bitcoin/src/script/interpreter.cpp")
         .file("depend/bitcoin/src/script/script.cpp")
         .file("depend/bitcoin/src/script/script_error.cpp")
+        .file("depend/bitcoin/src/secp256k1/src/secp256k1.c")
         .compile("libbitcoinconsensus.a");
 }

--- a/build.rs
+++ b/build.rs
@@ -6,10 +6,8 @@ fn main() {
     let mut base_config = cc::Build::new();
     base_config
         .cpp(true)
-        .include("bitcoin/src")
-        .include("bitcoin/src/secp256k1/include")
-        .opt_level(2)
-        .debug(true)
+        .include("depend/bitcoin/src")
+        .include("depend/bitcoin/src/secp256k1/include")
         .define("__STDC_FORMAT_MACROS", None);
 
     let tool = base_config.get_compiler();
@@ -24,19 +22,19 @@ fn main() {
             .define("WIN32", Some("1"));
     }
     base_config
-        .file("bitcoin/src/utilstrencodings.cpp")
-        .file("bitcoin/src/uint256.cpp")
-        .file("bitcoin/src/pubkey.cpp")
-        .file("bitcoin/src/hash.cpp")
-        .file("bitcoin/src/primitives/transaction.cpp")
-        .file("bitcoin/src/crypto/ripemd160.cpp")
-        .file("bitcoin/src/crypto/sha1.cpp")
-        .file("bitcoin/src/crypto/sha256.cpp")
-        .file("bitcoin/src/crypto/sha512.cpp")
-        .file("bitcoin/src/crypto/hmac_sha512.cpp")
-        .file("bitcoin/src/script/bitcoinconsensus.cpp")
-        .file("bitcoin/src/script/interpreter.cpp")
-        .file("bitcoin/src/script/script.cpp")
-        .file("bitcoin/src/script/script_error.cpp")
+        .file("depend/bitcoin/src/utilstrencodings.cpp")
+        .file("depend/bitcoin/src/uint256.cpp")
+        .file("depend/bitcoin/src/pubkey.cpp")
+        .file("depend/bitcoin/src/hash.cpp")
+        .file("depend/bitcoin/src/primitives/transaction.cpp")
+        .file("depend/bitcoin/src/crypto/ripemd160.cpp")
+        .file("depend/bitcoin/src/crypto/sha1.cpp")
+        .file("depend/bitcoin/src/crypto/sha256.cpp")
+        .file("depend/bitcoin/src/crypto/sha512.cpp")
+        .file("depend/bitcoin/src/crypto/hmac_sha512.cpp")
+        .file("depend/bitcoin/src/script/bitcoinconsensus.cpp")
+        .file("depend/bitcoin/src/script/interpreter.cpp")
+        .file("depend/bitcoin/src/script/script.cpp")
+        .file("depend/bitcoin/src/script/script_error.cpp")
         .compile("libbitcoinconsensus.a");
 }

--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,7 @@ fn main() {
     } else {
         false
     };
+    let target = env::var("TARGET").expect("TARGET was not set");
     let mut base_config = cc::Build::new();
     base_config
         .cpp(true)
@@ -51,9 +52,9 @@ fn main() {
     } else if tool.is_like_clang() || tool.is_like_gnu() {
         base_config.flag("-std=c++11").flag("-Wno-unused-parameter");
     }
-    #[cfg(target_os = "windows")]
-    {
-        base_config.define("WIN32", Some("1"));
+
+    if target.contains("windows") {
+        base_config.define("WIN32", "1");
     }
     base_config
         .file("depend/bitcoin/src/utilstrencodings.cpp")

--- a/depend/check_uint128_t.c
+++ b/depend/check_uint128_t.c
@@ -1,0 +1,16 @@
+
+#include <stdint.h>
+
+int main(void) {
+    __uint128_t var_128;
+    uint64_t var_64;
+
+    /* Try to shut up "unused variable" warnings */
+    var_64 = 100;
+    var_128 = 100;
+    if (var_64 == var_128) {
+        var_64 = 20;
+    }
+    return 0;
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,6 @@ pub fn verify_with_flags (spent_output_script: &[u8], amount: u64, spending_tran
 #[cfg(test)]
 mod tests {
     extern crate rustc_serialize as serialize;
-    extern crate secp256k1;
 
     use super::*;
     use self::serialize::hex::FromHex;


### PR DESCRIPTION
Hi,
as talked on IRC, this removes rust-secp256k1 as a dependency and compiles libsecp by it self.