### PR TITLE
Fix exclude folders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/rust-bitcoin/rust-bitcoinconsensus/"
 description = "Bitcoin's libbitcoinconsensus with Rust binding."
 keywords = [ "bitcoin", "bitcoinconsensus", "libbitcoinconsensus" ]
 readme = "README.md"
-exclude = ["/bitcoin/.github/**", "/bitcoin/.tx/**", "/bitcoin/build-aux/**", "/bitcoin/contrib/**", "/bitcoin/depends/**", "/bitcoin/doc/**", "/bitcoin/share/**", "/bitcoin/test/**", "/bitcoin/src/bench/**", "/bitcoin/src/config/**", "/bitcoin/src/consensus/**", "/bitcoin/src/leveldb/**", "/bitcoin/src/objtest/**", "/bitcoin/src/obj/**", "/bitcoin/src/policy/**", "/bitcoin/src/qt/**", "/bitcoin/src/rpc/**", "/bitcoin/src/support/**", "/bitcoin/src/test/**", "/bitcoin/src/univalue/**", "/bitcoin/src/wallet/**", "/bitcoin/src/zmq/**"]
+exclude = ["/depend/bitcoin/.github/**", "/depend/bitcoin/.tx/**", "/depend/bitcoin/build-aux/**", "/depend/bitcoin/contrib/**", "/depend/bitcoin/depends/**", "/depend/bitcoin/doc/**", "/depend/bitcoin/share/**", "/depend/bitcoin/test/**", "/depend/bitcoin/src/bench/**", "/depend/bitcoin/src/config/**", "/depend/bitcoin/src/consensus/**", "/depend/bitcoin/src/leveldb/**", "/depend/bitcoin/src/policy/**", "/depend/bitcoin/src/qt/**", "/depend/bitcoin/src/rpc/**", "/depend/bitcoin/src/support/**", "/depend/bitcoin/src/test/**", "/depend/bitcoin/src/univalue/**", "/depend/bitcoin/src/wallet/**", "/depend/bitcoin/src/zmq/**"]
 build = "build.rs"
 
 [lib]


### PR DESCRIPTION
I noticed older versions were around 750kb. 0.19.0-1 is 7,33 MB which means folders were not being excluded. This bug was introduced in https://github.com/rust-bitcoin/rust-bitcoinconsensus/pull/14 and is fixed with this PR. 