### PR TITLE
Add ERR_INVALID_FLAGS error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,4 +211,9 @@ mod tests {
     fn verify_test (spent : &str, spending :&str, amount :u64, input: usize) -> Result<(),Error> {
         verify (spent.from_hex().unwrap().as_slice(), amount, spending.from_hex().unwrap().as_slice(), input)
     }
+
+    #[test]
+    fn invalid_flags_test() {
+        verify_with_flags(&[], 0, &[], 0, VERIFY_ALL + 1).unwrap_err();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,9 @@ pub enum Error {
     #[allow(dead_code)]
     ERR_TX_DESERIALIZE,
     #[allow(dead_code)]
-    ERR_AMOUNT_REQUIRED
+    ERR_AMOUNT_REQUIRED,
+    #[allow(dead_code)]
+    ERR_INVALID_FLAGS
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
I'm not familiar with unsafe but from what I've observed, if this error is returned from libbitcoinconsensus there is UB.

After adding dbg!(&error) and passing in invalid flags
```
(signal: 11, SIGSEGV: invalid memory reference)
```

I noticed this when I playing around with adding taproot support. I expected a flag error but got Ok. Again, I'm not too familiar but maybe this is caused by the null pointer optimization?

I've attached a test that fails before this change and passes after