### PR TITLE
bump version to 0.19.0-3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,9 @@ rust:
   - nightly
   - 1.22.0
 
+script:
+  - cargo generate-lockfile --verbose
+  - cargo update -p cc --precise "1.0.41" --verbose
+  - cargo build --verbose
+  - cargo test --verbose
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoinconsensus"
-version = "0.19.0-2"
+version = "0.19.0-3"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoinconsensus/"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,5 +44,4 @@ install:
 build: false
 
 test_script:
-  - cargo generate-lockfile --verbose && cargo update -p cc --precise "1.0.41" --verbose
-    cargo test
+  - cargo generate-lockfile --verbose && cargo update -p cc --precise "1.0.41" --verbose && cargo test


### PR DESCRIPTION
Changes since 0.19.0-2 were to add some extra `#derive`s, fix some dep pinning in Cargo.toml, and changing `u64` to `uint64_t` in a couple of places in the FFI.