### PR TITLE
Document the unusual version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "bitcoinconsensus"
+# The first part is the Bitcoin Core version, the second part is the version of this lib.
 version = "0.19.0-0.4.0"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
We use a version number that is not correct semvar. This is done because the version references the version of Bitcoin Core vendored in `depend`.

Add documentation to the version number so the next dev reading it doesn't post an issue asking why the unusual format.