### PR TITLE
Remove libc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ std = []
 external-secp = []
 
 [dependencies]
-libc="0.2"
 
 [build-dependencies]
 cc = "1.0.28"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,11 @@
 //! sources using Cargo and provides Rust bindings to its API.
 //!
 
-extern crate libc;
+mod types;
 
 use core::fmt;
 
-use libc::{c_int, c_uchar, c_uint};
+use crate::types::*;
 
 /// Errors returned by `libbitcoinconsensus` (see github.com/bitcoin/bitcoin/doc/shared-libraries.md).
 #[allow(non_camel_case_types)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,26 @@
+// Written by the Rust Bitcoin developers.
+// SPDX-License-Identifier: CC0-1.0
+
+#![allow(non_camel_case_types)]
+
+/// The C signed 32 bit integer type.
+pub type c_int = i32;
+/// The C unsigned 8 bit integer type.
+pub type c_uchar = u8;
+/// The C unsigned 32 bit integer type.
+pub type c_uint = u32;
+
+#[cfg(test)]
+mod tests {
+    use std::any::TypeId;
+    use std::os::raw;
+
+    use crate::types;
+
+    #[test]
+    fn verify_types() {
+        assert_eq!(TypeId::of::<types::c_int>(), TypeId::of::<raw::c_int>());
+        assert_eq!(TypeId::of::<types::c_uchar>(), TypeId::of::<raw::c_uchar>());
+        assert_eq!(TypeId::of::<types::c_uint>(), TypeId::of::<raw::c_uint>());
+    }
+}


### PR DESCRIPTION
As we do in `rust-secp256k1` we can create type aliases for C integer types instead of depending on `libc`.

Create type aliases (copied from `rust-secp256k1`) and remove libc dependency.

Please note, this crate is copyright'ed to Tamas using Apache, but for this new file we use CC license since I copied it from `rust-secp256k1` (although its only a few trivial lines). Probably being overly paranoid but wanted to flag it.

Fixes: #57 