### PR TITLE
Depend on bitflags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ std = []
 external-secp = []
 
 [dependencies]
+bitflags = "1.2.1"
 libc="0.2"
 
 [build-dependencies]


### PR DESCRIPTION
Currently we are manually creating C-like bitflags, there is a crate for this. In order to support our MSRV we cannot use the latest version of `bitflags` (which is v1.3.2 ATM), instead use v1.2.1.

FTR I tested the new flags during development using
```
    #[test]
    fn verify_flags() {
        assert_eq!(VERIFY_NONE, Flags::VERIFY_NONE.bits);
        assert_eq!(VERIFY_NONE, Flags::VERIFY_NONE.bits);
        assert_eq!(VERIFY_P2SH, Flags::VERIFY_P2SH.bits);
        assert_eq!(VERIFY_DERSIG, Flags::VERIFY_DERSIG.bits);
        assert_eq!(VERIFY_NULLDUMMY, Flags::VERIFY_NULLDUMMY.bits);
        assert_eq!(VERIFY_CHECKLOCKTIMEVERIFY, Flags::VERIFY_CHECKLOCKTIMEVERIFY.bits);
        assert_eq!(VERIFY_CHECKSEQUENCEVERIFY, Flags::VERIFY_CHECKSEQUENCEVERIFY.bits);
        assert_eq!(VERIFY_WITNESS, Flags::VERIFY_WITNESS.bits);
        assert_eq!(VERIFY_ALL, Flags::VERIFY_ALL.bits);
    }
```

Note also, that this patch removes the unit test for invalid flags - because invalid flags are now impossible, BOOM!

Fixes: #58