### PR TITLE
Introduce SPDX identifiers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,6 @@
-//
 // Copyright 2018 Tamas Blummer
-//
-//Licensed under the Apache License, Version 2.0 (the "License");
-//you may not use this file except in compliance with the License.
-//You may obtain a copy of the License at
-//
-//http://www.apache.org/licenses/LICENSE-2.0
-//
-//Unless required by applicable law or agreed to in writing, software
-//distributed under the License is distributed on an "AS IS" BASIS,
-//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//See the License for the specific language governing permissions and
-//limitations under the License.
-//
+// SPDX-License-Identifier: Apache-2.0
+
 //! This project builds the `libbitcoinconsensus` library from Bitcoin's C++
 //! sources using Cargo and provides Rust bindings to its API.
 //!


### PR DESCRIPTION
The SPDX license list and SPDX license identifiers are a standard terse way to add license information to source code files.

Remove the licence information and replace it with an SPDX ID (see https://spdx.dev/ids/#how).

This was done in `rust-bitcoin` in PR: https://github.com/rust-bitcoin/rust-bitcoin/pull/1076