### PR TITLE
Release tracking PR - `v0.20.2-0.6.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# Unreleased
+## v0.20.2-0.6.0
 
 * Bump MSRV to rust 1.48.0 [#64](https://github.com/rust-bitcoin/rust-bitcoinconsensus/pull/64)
+* De-clutter the public API by moving creating an `ffi` submodule
 
 ## v0.20.2-0.5.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitcoinconsensus"
 # The first part is the Bitcoin Core version, the second part is the version of this lib.
-version = "0.20.2-0.5.0"
+version = "0.20.2-0.6.0"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoinconsensus/"


### PR DESCRIPTION
In preparation for release bump the version and add a changelog entry.

