### PR TITLE
Derive additional traits for error type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.20.2-0.6.1
+
+- Add derives on error type [#72](https://github.com/rust-bitcoin/rust-bitcoinconsensus/pull/72)
+
 ## v0.20.2-0.6.0
 
 * Bump MSRV to rust 1.48.0 [#64](https://github.com/rust-bitcoin/rust-bitcoinconsensus/pull/64)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitcoinconsensus"
 # The first part is the Bitcoin Core version, the second part is the version of this lib.
-version = "0.20.2-0.6.0"
+version = "0.20.2-0.6.1"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoinconsensus/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ pub mod ffi {
 ///
 /// [`libbitcoinconsensus`]: <https://github.com/bitcoin/bitcoin/blob/master/doc/shared-libraries.md#errors>
 #[allow(non_camel_case_types)]
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub enum Error {
     /// Default value, passed to `libbitcoinconsensus` as a return parameter.


### PR DESCRIPTION
The recent `0.20.2-0.6.0` release brakes the `rust-bitcoin` build. Epic fail by me for not testing that before pushing the release PR.

Back in February this year I must have been mad, commit:

 `2bbfc28e754cb823576fe80bbfa96e2eea278173 Only derive Debug for error type`

removed all the derives from the error type except `Debug`. This makes the error type un-ergonomic to use downstream and breaks the `rust-bitcoin` build.

Fix by deriving what has become our standard set of derives for error types in the `rust-bitcoin` eccosystem. Also include `Copy` because this error is exhaustive.