### PR TITLE
Change the crate version format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.100.0+0.20.2
+
+- Change the crate version format [#75](https://github.com/rust-bitcoin/rust-bitcoinconsensus/pull/75)
+
 ## v0.20.2-0.6.1
 
 - Add derives on error type [#72](https://github.com/rust-bitcoin/rust-bitcoinconsensus/pull/72)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitcoinconsensus"
-# The first part is the Bitcoin Core version, the second part is the version of this lib.
-version = "0.20.2-0.6.1"
+# The first part is the crate version, the second informational part is the Bitcoin Core version.
+version = "0.100.0+0.20.2"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoinconsensus/"


### PR DESCRIPTION
Currently we use a version string of the form `0.20.2-0.6.1`

While attempting to release of the `0.6` we found out that cargo ignores the stuff after the `-` so the newly released code is treated as a non-breaking change and pulled immediately by any crate that has `bitcoinconsensus` in its dependency graph. This broke everyone that uses it including `rust-bitcoin`.

We have since yanked both the `0.6` releases.

In order to function correctly with `cargo` change the format to put the crate version first and put the Core version second, note we use `+` (build) instead of `-` (pre-release). This should make `crates.io` display the latest version correctly also.