### PR TITLE
Release tracking PR: `v0.101.1+0.21-final`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-## 0.101.0+0.21.2
+## 0.101.0+0.21-final - 2024-01-13
+
+* Vendor Bitcoin Core `v0.21-final`
+
+## 0.101.0+0.21.2 - 2024-01-11
 
 * Vendor Bitcoin Core `v0.21.2`
 
-## 0.100.0+0.20.2
+## 0.100.0+0.20.2 - 2023-12-14
 
 - Change the crate version format [#76](https://github.com/rust-bitcoin/rust-bitcoinconsensus/pull/76)
 

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "bitcoinconsensus"
-version = "0.101.0+0.21.2"
+version = "0.101.1+0.21-final"
 dependencies = [
  "cc",
  "rustc-serialize",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "bitcoinconsensus"
-version = "0.101.0+0.21.2"
+version = "0.101.1+0.21-final"
 dependencies = [
  "cc",
  "rustc-serialize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitcoinconsensus"
 # The first part is the crate version, the second informational part is the Bitcoin Core version.
-version = "0.101.0+0.21.2"
+version = "0.101.1+0.21-final"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoinconsensus/"


### PR DESCRIPTION
Add a changelog entry, bump the version, and update the lock files. There are no patches other than vendoring new Core vension since the 0.101.0+0.21.2 release.
    
Note, we forgot to include a date when releasing the last two releases, grab the dates from crates.io and add them.

