### PR TITLE
Fix changelog heading version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.101.0+0.21-final - 2024-01-13
+## 0.101.1+0.21-final - 2024-01-13
 
 * Vendor Bitcoin Core `v0.21-final`
 


### PR DESCRIPTION
I accidentally used the wrong version number in the changelog entry, fix it up.

FTR I verified crates.io is correct, and fixed tags which had this same mistake - my bad.