### PR TITLE
Release tracking PR: `v0.102.0+22.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# Unreleased
+## 0.102.0+22.1 - 2024-01-23
 
 * Stop testing on `s390x-unknow-linux-gnu` - we cannot currently get Core v22.2 to build on this target.
+* Vendor Bitcoin Core `v22.1`
 
 ## 0.101.1+0.21-final - 2024-01-13
 

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "bitcoinconsensus"
-version = "0.101.1+0.21-final"
+version = "0.102.0+22.1"
 dependencies = [
  "cc",
  "rustc-serialize",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "bitcoinconsensus"
-version = "0.101.1+0.21-final"
+version = "0.102.0+22.1"
 dependencies = [
  "cc",
  "rustc-serialize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitcoinconsensus"
 # The first part is the crate version, the second informational part is the Bitcoin Core version.
-version = "0.101.1+0.21-final"
+version = "0.102.0+22.1"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoinconsensus/"


### PR DESCRIPTION
Add a changelog entry, bump the version, and update the lock files.