### PR TITLE
Remove SECP256K1_BUILD

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -38,7 +38,6 @@ fn main() {
             .include("depend/bitcoin/src/secp256k1")
             .include("depend/bitcoin/src/secp256k1/src")
             .flag_if_supported("-Wno-unused-function") // some ecmult stuff is defined but not used upstream
-            .define("SECP256K1_BUILD", "1")
             // Bitcoin core defines libsecp to *not* use libgmp.
             .define("USE_NUM_NONE", "1")
             .define("USE_FIELD_INV_BUILTIN", "1")


### PR DESCRIPTION
Setting this variable causes a build warning, removing it doesn't seem to break anything and removes the warning. Also we do not set this variable when building `secp256k1-sys` over in the secp crate.

I have no idea what the variable was intended to do though.