### PR TITLE
Bump version to v0.104.0+24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.104.0+24.2 - 2024-03-03
+
+* Vendor Bitcoin Core `v24.2`
+
 ## 0.103.0+23.2 - 2024-01-31
 
 * Vendor Bitcoin Core `v23.2`

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "bitcoinconsensus"
-version = "0.103.0+23.2"
+version = "0.104.0+24.2"
 dependencies = [
  "cc",
  "rustc-serialize",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "bitcoinconsensus"
-version = "0.103.0+23.2"
+version = "0.104.0+24.2"
 dependencies = [
  "cc",
  "rustc-serialize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitcoinconsensus"
 # The first part is the crate version, the second informational part is the Bitcoin Core version.
-version = "0.103.0+23.2"
+version = "0.104.0+24.2"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoinconsensus/"


### PR DESCRIPTION
Add a changelog entry, bump the version, and update the lock files.