### PR TITLE
secp256k1: enable ellswift module

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -42,7 +42,9 @@ fn main() {
             .define("ECMULT_GEN_PREC_BITS", "4")
             .define("ENABLE_MODULE_SCHNORRSIG", "1")
             .define("ENABLE_MODULE_EXTRAKEYS", "1")
-            // Technically libconsensus doesn't require the recovery feautre, but `pubkey.cpp` does.
+            // Technically libconsensus doesn't require the ellswift and recovery features, but
+            // `pubkey.cpp` does.
+            .define("ENABLE_MODULE_ELLSWIFT", "1")
             .define("ENABLE_MODULE_RECOVERY", "1")
             .file("depend/bitcoin/src/secp256k1/src/precomputed_ecmult_gen.c")
             .file("depend/bitcoin/src/secp256k1/src/precomputed_ecmult.c")


### PR DESCRIPTION
When running `cargo tarpaulin` (for test coverage) in a project that depends on this crate, compilation fails with:

```
= note: /usr/bin/ld: /rust-bitcoinconsensus/target/debug/build/bitcoinconsensus-6e1dd1af27ef0a27/out/libbitcoinconsensus.a(0ad13e9c6ad06456-pubkey.o): in function `EllSwiftPubKey::Decode() const':
          /rust-bitcoinconsensus/depend/bitcoin/src/pubkey.cpp:355: undefined reference to `secp256k1_ellswift_decode'
          collect2: error: ld returned 1 exit status

```

I am not sure why it's not a problem when compiling using `cargo test`, but the code does reference this function, so the module should be enabled.